### PR TITLE
The given unit is not mph but m/s

### DIFF
--- a/plot.py
+++ b/plot.py
@@ -77,7 +77,7 @@ def read_hr_bodge(hrfile):
     return track_data
 
 def speed_conversion(raw):
-    return raw * 1.60934 * 2.0 # convert mph to kph, plus some scaling fudge factor
+    return 3.6*raw # convert m/s to km/h
 
 def plot_osm_map(track, output='speed-map.html', hr=None):
     for i in range(len(track['speed'])):


### PR DESCRIPTION
Hey,
I took you script as a base to write my own visualization script and was confused about the speed conversion. 
In [this](https://gis.stackexchange.com/questions/74222/what-are-the-units-for-garmins-gpx-gpxtpxspeed) SO post an answer referenced [the garmin documentation]( http://www8.garmin.com/xmlschemas/TrackPointExtensionv2.xsd) where they write that the speed unit is m/s. So the factor to get to km/h is 3.6.